### PR TITLE
Add 7sus2 to CHORD_DATA

### DIFF
--- a/src/CHORD_DATA.js
+++ b/src/CHORD_DATA.js
@@ -48,6 +48,7 @@ const CHORD_DATA = [
   ['1P 4P 5P', '', 'sus4', 'sus', 'suspended 4th'],
   ['1P 2M 5P', '', 'sus2', '', 'suspended 2nd'],
   ['1P 4P 5P 7m', '', '7sus4', '', 'suspended 4th seventh'],
+  ['1P 2M 5P 7m', '', '7sus2', '', 'suspended 2nd seventh'],
   ['1P 5P 7m 9M 11P', '', '11', '', 'eleventh'],
   ['1P 4P 5P 7m 9m', '', '', 'sus4b9 susb9 (b9)sus phryg', 'suspended 4th b9'],
   ['1P 5P', '', '5', '', 'fifth'],


### PR DESCRIPTION
Add support for suspended 2nd seventh chords.

[Demo](https://www.naadanchords.com/railai-thallum-meghame-blue-star) screenshot of D7sus2 chord rendered using [vexchords](https://github.com/0xfe/vexchords)

<img width="542" alt="Screenshot 2024-06-01 at 5 24 14 PM" src="https://github.com/hyvyys/chord-fingering/assets/1595593/29ed84b2-17e6-477d-b058-0d0bfcaba364">
