### PR TITLE
Fix dom 7th chord data

### DIFF
--- a/src/CHORD_DATA.js
+++ b/src/CHORD_DATA.js
@@ -38,7 +38,7 @@ const CHORD_DATA = [
   ['1P 3m 5d', '', 'dim', '° o', 'diminished'],
   ['1P 3m 5d 7d', '', 'dim7', '°7 o7', 'diminished seventh'],
   ['1P 3m 5d 7m', '', 'm7b5', 'ø', 'half-diminished'],
-  ['1P 3M 5P 7m', '', '7', 'dom', 'dominant seventh'],
+  ['1P 3M 5P 7m', '5P', '7', 'dom', 'dominant seventh'],
   ['1P 3M 5P 7m 9M', '5P', '9', '', 'dominant ninth'],
   ['1P 3M 5P 7m 9M 13M', '3M 5P', '13', '', 'dominant thirteenth'],
   ['1P 3M 5P 7m 11A', '3M', '7#11', '7#4', 'lydian dominant seventh'],

--- a/src/fingerings.test.js
+++ b/src/fingerings.test.js
@@ -168,4 +168,8 @@ describe('fingerings', () => {
   it('sort Bm fingerings correctly', () => {
     expect(pos('Bm', 0)).toBe('x24432');
   });
+
+  it('sort C7 fingerings correctly', () => {
+    expect(pos('C7', 4)).toBe('x32310');
+  });
 });


### PR DESCRIPTION
Make '5P' optional  in `src/CHORD_DATA.js` to allow voicings that omit the fifth, such as `'x32310'` for C7 Guitar chord:

<img width="380" alt="image" src="https://github.com/user-attachments/assets/fc81f8a9-e3e2-4318-a0cf-cf69b8ad0f75" />

Ref: https://www.reddit.com/r/guitarlessons/comments/x625p0/why_there_is_no_g_note_in_this_c7_chord_shouldnt